### PR TITLE
Add try/catch to `useData()`

### DIFF
--- a/shairport-sync-reader-base.js
+++ b/shairport-sync-reader-base.js
@@ -48,6 +48,7 @@ class ShairportSyncReader extends EventEmitter {
 		return cont;
 	}
 	useData(data) {
+		try {
 		if (data.type == 'ssnc') {
 			if (data.code !== 'PICT') {
 				data.cont = data.cont.toString();
@@ -94,6 +95,9 @@ class ShairportSyncReader extends EventEmitter {
 			}
 		} else {
 			this._meta[data.code] = parser.parseTag(data.code, data.cont);
+		}
+		} catch (e) {
+			console.log(e)
 		}
 	}
 }


### PR DESCRIPTION
This prevents the app from crashing with error `RangeError [ERR_OUT_OF_RANGE]: The value of "byteLength" is out of range. It must be >= 1 and <= 6. Received 8`

This error occurs when using shairport-sync-reader with preview samples of Apple iTunes Store.

Adding try/catch doesn’t fix the inherent problem, it just keeps the app going. I have to admit that I’m not able to propose a proper fix.

Example of error message :

```
events.js:170
      throw er; // Unhandled 'error' event
      ^

RangeError [ERR_OUT_OF_RANGE]: The value of "byteLength" is out of range. It must be >= 1 and <= 6. Received 8
    at boundsError (internal/buffer.js:58:9)
    at Buffer.readUIntBE (internal/buffer.js:169:3)
    at Object.number (/home/pi/Documents/metadataReader/node_modules/daap-parser/daapparser.js:25:15)
    at Object.tag [as parseTag] (/home/pi/Documents/metadataReader/node_modules/daap-parser/daapparser.js:83:88)
    at ShairportSyncReaderPipe.useData (/home/pi/Documents/metadataReader/shairport-sync-reader-base.js:99:35)
    at result.item.forEach.item (/home/pi/Documents/metadataReader/shairport-sync-reader-pipe.js:59:10)
    at Array.forEach (<anonymous>)
    at xml2js.parseString (/home/pi/Documents/metadataReader/shairport-sync-reader-pipe.js:42:16)
    at Parser.<anonymous> (/home/pi/Documents/metadataReader/node_modules/xml2js/lib/parser.js:303:18)
    at Parser.emit (events.js:193:13)
Emitted 'error' event at:
    at Parser.exports.Parser.Parser.parseString (/home/pi/Documents/metadataReader/node_modules/xml2js/lib/parser.js:326:16)
    at Parser.parseString (/home/pi/Documents/metadataReader/node_modules/xml2js/lib/parser.js:5:59)
    at Object.exports.parseString (/home/pi/Documents/metadataReader/node_modules/xml2js/lib/parser.js:354:19)
    at ShairportSyncReaderPipe._readChunk (/home/pi/Documents/metadataReader/shairport-sync-reader-pipe.js:34:10)
    at ReadStream.emit (events.js:193:13)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:276:11)
    at ReadStream.Readable.push (_stream_readable.js:231:10)
    at fs.read (internal/fs/streams.js:183:12)
    at FSReqCallback.wrapper [as oncomplete] (fs.js:478:5)
[nodemon] app crashed - waiting for file changes before starting…
```