### PR TITLE
bug fixes to make images more reliable when reading from the web socket

### DIFF
--- a/shairport-sync-reader-base.js
+++ b/shairport-sync-reader-base.js
@@ -67,16 +67,16 @@ class ShairportSyncReader extends EventEmitter {
 			switch (data.code) {
 				case 'mdst':
 					this._meta = {};
-					this._rtptime.meta = data.cont;
+					this._rtptime.meta = data.cont;					
 					break;
 				case 'mden':
 					this.emit('meta', this._meta);
 					break;
 				case 'pcst':
-					this._rtptime.pict = data.cont;
+					this._pictStart = true;
 					break;
 				case 'pcen':
-					delete this._rtptime.pict;
+					this._pictStart = false;
 					break;
 				case 'stal':
 					this.emit('error', data.code);
@@ -85,7 +85,7 @@ class ShairportSyncReader extends EventEmitter {
 					this.emit('client', data.cont);
 					break;
 				case 'PICT':
-					if (this._rtptime.pict === this._rtptime.meta && data.cont.length) {
+					if (this._pictStart && data.cont.length) {
 						this.emit(data.code, data.cont);
 					}
 					break;

--- a/shairport-sync-reader-udp.js
+++ b/shairport-sync-reader-udp.js
@@ -28,6 +28,7 @@ class ShairportSyncReaderUDP extends ShairportSyncReader {
 						code: msg.toString('utf8', 20, 24),
 						cont: this._chunked,
 					});
+					this._total = 0;
 				}
 			} else {
 				if (!this._total) {


### PR DESCRIPTION
Changes to fix an issue I was having with getting image information reliably using the udp reader. Image data chunks where not all being received with the same timestamp so many images did not raise a 'PICT' event. I changed it to use a flag instead. This has improved the behavior and PICT events are reliably raised now when reading from the web socket.